### PR TITLE
Add label translation within BootstrapRow

### DIFF
--- a/src/ZucchiBootstrap/Form/View/Helper/BootstrapRow.php
+++ b/src/ZucchiBootstrap/Form/View/Helper/BootstrapRow.php
@@ -197,6 +197,12 @@ class BootstrapRow extends FormRow
             $elementString       = $elementHelper->render($element);
             
             $elementString = $this->renderBootstrapOptions($elementString, $bootstrapOptions);
+
+            if (!empty($label) && null !== ($translator = $this->getTranslator())) {
+                $label = $translator->translate(
+                    $label, $this->getTranslatorTextDomain()
+                );
+            }
             
             $markup = sprintf($this->defaultElementTemplates[$formStyle],
                 $labelOpen,


### PR DESCRIPTION
The translation of the label within BootstrapRow was missing. In this change translation is added just as it is present within the BootstrapCollection.
